### PR TITLE
Don't bypass email confirmation

### DIFF
--- a/packages/vulcan-forms/lib/components/FormGroup.jsx
+++ b/packages/vulcan-forms/lib/components/FormGroup.jsx
@@ -72,7 +72,7 @@ class FormGroup extends PureComponent {
     const { classes, name, defaultStyle, flexStyle} = this.props
     const groupStyling = !(name == 'default' || defaultStyle)
     return (
-      <div className={groupStyling && classes.formSection}>
+      <div className={groupStyling ? classes.formSection : undefined}>
         { groupStyling && this.renderHeading()}
         { (!this.state.collapsed || this.hasErrors()) &&
           <div className={classNames(classes.formSectionFields, {[classes.formSectionBody]: groupStyling, [classes.flex]: flexStyle})}

--- a/packages/vulcan-users/lib/server/callbacks.js
+++ b/packages/vulcan-users/lib/server/callbacks.js
@@ -62,7 +62,7 @@
         user.emails[0].verified = false;
         modifier.$set.emails = user.emails;
       } else {
-        user.emails = [{address: newEmail, verified: false}];
+        modifier.$set.emails = [{address: newEmail, verified: false}];
       }
 
       // update email hash

--- a/packages/vulcan-users/lib/server/callbacks.js
+++ b/packages/vulcan-users/lib/server/callbacks.js
@@ -59,9 +59,10 @@
       // if user.emails exists, change it too
       if (!!user.emails) {
         user.emails[0].address = newEmail;
+        user.emails[0].verified = false;
         modifier.$set.emails = user.emails;
       } else {
-        user.emails = [{address: newEmail, verified: true}];
+        user.emails = [{address: newEmail, verified: false}];
       }
 
       // update email hash


### PR DESCRIPTION
When you edit the email address on your account, Vulcan would set the new, definitely-no-verification-email-sent to verified. Fix that.