### PR TITLE
Set enableTotal by default to false in withMulti

### DIFF
--- a/packages/vulcan-core/lib/modules/containers/withMulti.js
+++ b/packages/vulcan-core/lib/modules/containers/withMulti.js
@@ -52,7 +52,7 @@ export default function withMulti(options) {
   const {
     limit = 10,
     pollInterval = getSetting('pollInterval', 0),
-    enableTotal = true,
+    enableTotal = false,
     enableCache = false,
     extraQueries,
     ssr = false


### PR DESCRIPTION
This fixes a regression that might be the cause of our recent performance problems, by disabling the totalCount resolver by default, which is quite costly on our large database. I thought we had overriden this in lots of places, but we changed it to be off by default, and changing that back might have caused a bunch of unnecessary expensive count queries. 