### PR TITLE
Make nested-form components customizable

### DIFF
--- a/packages/vulcan-forms/lib/components/FormComponent.jsx
+++ b/packages/vulcan-forms/lib/components/FormComponent.jsx
@@ -253,8 +253,15 @@ class FormComponent extends Component {
           return Components.FormComponentStaticText;
 
         default:
-          const CustomComponent = Components[this.props.input];
-          return CustomComponent ? CustomComponent : Components.FormComponentDefault;
+          if (this.props.input && Components[this.props.input]) {
+            return Components[this.props.input];
+          } else if (this.isArrayField()) {
+            return Components.FormNestedArray;
+          } else if (this.isObjectField()) {
+            return Components.FormNestedObject;
+          } else {
+            return Components.FormComponentDefault;
+          }
       }
     }
   };
@@ -272,11 +279,12 @@ class FormComponent extends Component {
     if (this.props.intlInput) {
       return <Components.FormIntl {...this.props} />;
     } else if (this.props.nestedInput) {
-      if (this.isArrayField()) {
-        return <Components.FormNestedArray {...this.props} errors={this.getErrors()} value={this.getValue()}/>;
-      } else if (this.isObjectField()) {
-        return <Components.FormNestedObject {...this.props} errors={this.getErrors()} value={this.getValue()}/>;
-      }
+      const inputComponent = this.getFormInput();
+      return React.createElement(inputComponent, {
+        ...this.props,
+        errors: this.getErrors(),
+        value: this.getValue()
+      });
     }
     return (
       <Components.FormComponentInner


### PR DESCRIPTION
Used in the notifications branch. This makes it possible to replace 'Components.NestedArray' and 'Components.NestedObject' in vulcan-forms on a per-field basis, where before they could only be replaced by replacing the components globally.

Candidate for upstreaming into Vulcan.