### PR TITLE
Fix crash in markCallbacksStarted

### DIFF
--- a/packages/vulcan-lib/lib/modules/callbacks.js
+++ b/packages/vulcan-lib/lib/modules/callbacks.js
@@ -255,7 +255,7 @@ function markCallbackStarted(description)
   else
     pendingCallbackKey++;
   pendingCallbacks[pendingCallbackKey] = true;
-  return id;
+  return pendingCallbackKey;
 }
 
 // Record the fact that an async callback with the given ID has finished.


### PR DESCRIPTION
Last commit was somewhat messed up (I made a change to prevent running out of IDs, but it had an error of the sort lint would've caught, except we don't lint Vulcan. Oops)