### PR TITLE
Make Vulcan pass lint

### DIFF
--- a/.eslintrc
+++ b/.eslintrc
@@ -12,69 +12,64 @@
   },
   "rules": {
     "babel/generator-star-spacing": 0,
-    "babel/new-cap": [
-      1,
-      {
-        "capIsNewExceptions": [
-          "Optional",
-          "OneOf",
-          "Maybe",
-          "MailChimpAPI",
-          "Juice",
-          "Run",
-          "AppComposer",
-          "Query"
-        ]
-      }
-    ],
+    "babel/new-cap": [1, {
+      "capIsNewExceptions": [
+        "Optional",
+        "OneOf",
+        "Maybe",
+        "MailChimpAPI",
+        "Juice",
+        "Run",
+        "AppComposer",
+        "Query"
+      ]
+    }],
     "babel/array-bracket-spacing": 0,
     "babel/object-curly-spacing": 0,
     "babel/object-shorthand": 0,
     "babel/arrow-parens": 0,
-    "no-await-in-loop": 1,
+    "no-await-in-loop": 0,
     "comma-dangle": 0,
     "key-spacing": 0,
-    "meteor/audit-argument-checks": 0,
-    "no-case-declarations": 0,
-    "no-console": 1,
     "no-extra-boolean-cast": 0,
     "no-undef": 1,
-    "no-unused-vars": [
-      1,
-      {
-        "vars": "all",
-        "args": "none",
-        "varsIgnorePattern": "React|PropTypes|Component"
-      }
-    ],
-    "no-useless-escape": 0,
-    "quotes": [
-      1,
-      "single"
-    ],
-    "react/prop-types": 0
+    "no-unused-vars": [1, {
+      "vars": "all",
+      "args": "none",
+      "varsIgnorePattern": "React|PropTypes|Component"
+    }],
+    "no-console": 1,
+    "react/prop-types": 0,
+    "meteor/audit-argument-checks": 0,
+    "no-case-declarations": 0,
+    "react/no-unescaped-entities": 0
   },
   "env": {
     "browser": true,
     "commonjs": true,
     "es6": true,
     "meteor": true,
-    "node": true,
-    "mocha": true
+    "node": true
   },
   "plugins": [
     "babel",
     "meteor",
-    "react",
-    "prettier",
-    "mocha"
+    "react"
   ],
   "settings": {
-    "import/resolver": "meteor"
+    "import/resolver": "meteor",
+    "react": {
+        "version": "16.4.1"
+      }
   },
   "root": true,
   "globals": {
     "param": true,
-    "returns": true
+    "returns": true,
+    "describe": true,
+    "it": true,
+    "before": true,
+    "beforeEach": true,
+    "afterEach": true,
   }
 }

--- a/packages/vulcan-accounts/imports/ui/components/LoginFormInner.jsx
+++ b/packages/vulcan-accounts/imports/ui/components/LoginFormInner.jsx
@@ -633,8 +633,8 @@ export class AccountsLoginFormInner extends TrackerComponent {
 
     if (usernameOrEmail !== null) {
       if (!this.validateField('username', usernameOrEmail)) {
-        if (this.state.formState == STATES.SIGN_UP) {
-          this.state.onSubmitHook('error.accounts.usernameRequired', this.state.formState);
+        if (formState == STATES.SIGN_UP) {
+          onSubmitHook('error.accounts.usernameRequired', formState);
         }
         error = true;
       }
@@ -643,8 +643,8 @@ export class AccountsLoginFormInner extends TrackerComponent {
       }
     } else if (username !== null) {
       if (!this.validateField('username', username)) {
-        if (this.state.formState == STATES.SIGN_UP) {
-          this.state.onSubmitHook('error.accounts.usernameRequired', this.state.formState);
+        if (formState == STATES.SIGN_UP) {
+          onSubmitHook('error.accounts.usernameRequired', formState);
         }
         error = true;
       }

--- a/packages/vulcan-lib/lib/server/apollo_server.js
+++ b/packages/vulcan-lib/lib/server/apollo_server.js
@@ -40,6 +40,7 @@ const sentryRelease = getSetting('sentry.release')
 const Sentry = require('@sentry/node');
 Sentry.init({ dsn: sentryUrl, environment: sentryEnvironment, release: sentryRelease });
 if(!sentryUrl) {
+  // eslint-disable-next-line no-console
   console.warn("No sentry DNS found, to activate error reporting please set the sentry.url variable in your settings file")
 }
 

--- a/packages/vulcan-routing/lib/server/getDataFromTree.jsx
+++ b/packages/vulcan-routing/lib/server/getDataFromTree.jsx
@@ -29,11 +29,11 @@ function walkTree(element, context, visitor) {
     }
     // A stateless functional component or a class
     if (isReactElement(element)) {
+        var child = void 0;
         if (typeof element.type === 'function') {
             var Comp = element.type;
             var props = Object.assign({}, Comp.defaultProps, getProps(element));
             var childContext_1 = context;
-            var child = void 0;
             // Are we are a react class?
             if (isComponentClass(Comp)) {
                 var instance_1 = new Comp(props, context);
@@ -66,6 +66,7 @@ function walkTree(element, context, visitor) {
                     }
                 }
                 else if (instance_1.UNSAFE_componentWillMount) {
+                    // eslint-disable-next-line babel/new-cap
                     instance_1.UNSAFE_componentWillMount();
                 }
                 else if (instance_1.componentWillMount) {
@@ -84,6 +85,7 @@ function walkTree(element, context, visitor) {
                 if (visitor(element, null, context) === false) {
                     return;
                 }
+                // eslint-disable-next-line babel/new-cap
                 child = Comp(props, context);
             }
             if (child) {
@@ -100,7 +102,6 @@ function walkTree(element, context, visitor) {
             if (visitor(element, null, context) === false) {
                 return;
             }
-            var child = void 0;
             if (element.type._context) {
                 // A provider - sets the context value before rendering children
                 element.type._context._currentValue = element.props.value;

--- a/packages/vulcan-voting/lib/server/cron.js
+++ b/packages/vulcan-voting/lib/server/cron.js
@@ -1,10 +1,14 @@
-import { getSetting, registerSetting, debug } from 'meteor/vulcan:core';
 import { /*updateScore,*/ batchUpdateScore } from './scoring.js';
 import { VoteableCollections } from '../modules/make_voteable.js';
 import { SyncedCron } from 'meteor/percolatestudio:synced-cron';
 
-registerSetting('voting.scoreUpdateInterval', 60, 'How often to update scores, in seconds');
-const scoreInterval = parseInt(getSetting('voting.scoreUpdateInterval', 60));
+// Setting voting.scoreUpdateInterval removed and replaced with a hard-coded
+// interval because the time-parsing library we use can't handle numbers of
+// seconds >= 60; rather than treat them as minutes (like you'd expect), it
+// treats intervals like "every 100 seconds" as a syntax error.
+//
+//registerSetting('voting.scoreUpdateInterval', 60, 'How often to update scores, in seconds');
+//const scoreInterval = parseInt(getSetting('voting.scoreUpdateInterval', 60));
 
 SyncedCron.options = {
   log: true,


### PR DESCRIPTION
This makes our fork of Vulcan pass eslint. Note that it doesn't do any of the CircleCI configuration necessary to actually make eslint run, except locally when you `npm install; npm run lint`.