### PR TITLE
Add `setOnGraphQLError` for use in unit tests

### DIFF
--- a/packages/vulcan-lib/lib/server/query.js
+++ b/packages/vulcan-lib/lib/server/query.js
@@ -31,14 +31,24 @@ export const runGraphQL = async (query, variables = {}, context ) => {
   const result = await graphql(executableSchema, query, {}, queryContext, variables);
 
   if (result.errors) {
-    // eslint-disable-next-line no-console
-    console.error(`runGraphQL error: ${result.errors[0].message}`);
-    // eslint-disable-next-line no-console
-    console.error(result.errors);
+    if (onGraphQLError) {
+      onGraphQLError(result.errors);
+    } else {
+      // eslint-disable-next-line no-console
+      console.error(`runGraphQL error: ${result.errors[0].message}`);
+      // eslint-disable-next-line no-console
+      console.error(result.errors);
+    }
     throw new Error(result.errors[0].message);
   }
 
   return result;
+}
+
+var onGraphQLError = null;
+export function setOnGraphQLError(fn)
+{
+  onGraphQLError = fn;
 }
 
 export const runQuery = runGraphQL; //backwards compatibility

--- a/packages/vulcan-lib/lib/server/query.js
+++ b/packages/vulcan-lib/lib/server/query.js
@@ -14,6 +14,23 @@ import merge from 'lodash/merge';
 import { singleClientTemplate } from '../modules/graphql_templates';
 import { Utils } from './utils';
 
+function writeGraphQLErrorToStderr(errors)
+{
+  // eslint-disable-next-line no-console
+  console.error(`runGraphQL error: ${errors[0].message}`);
+  // eslint-disable-next-line no-console
+  console.error(errors);
+}
+
+let onGraphQLError = writeGraphQLErrorToStderr;
+export function setOnGraphQLError(fn)
+{
+  if (fn)
+    onGraphQLError = fn;
+  else
+    onGraphQLError = writeGraphQLErrorToStderr;
+}
+
 // note: if no context is passed, default to running requests with full admin privileges
 export const runGraphQL = async (query, variables = {}, context ) => {
 
@@ -31,24 +48,11 @@ export const runGraphQL = async (query, variables = {}, context ) => {
   const result = await graphql(executableSchema, query, {}, queryContext, variables);
 
   if (result.errors) {
-    if (onGraphQLError) {
       onGraphQLError(result.errors);
-    } else {
-      // eslint-disable-next-line no-console
-      console.error(`runGraphQL error: ${result.errors[0].message}`);
-      // eslint-disable-next-line no-console
-      console.error(result.errors);
-    }
     throw new Error(result.errors[0].message);
   }
 
   return result;
-}
-
-var onGraphQLError = null;
-export function setOnGraphQLError(fn)
-{
-  onGraphQLError = fn;
 }
 
 export const runQuery = runGraphQL; //backwards compatibility


### PR DESCRIPTION
Adds a hook which replaces the default behavior in response to GraphQL errors (write them to stderr) with a callback function. This supports unit tests in the LessWrong2 repo, where we're adding utility functions to collect those errors and assert their presence or absence.