### PR TITLE
Remove extra punctuation from reset-password confirmation

### DIFF
--- a/packages/vulcan-accounts/imports/ui/components/ResetPassword.jsx
+++ b/packages/vulcan-accounts/imports/ui/components/ResetPassword.jsx
@@ -20,7 +20,7 @@ class AccountsResetPassword extends PureComponent {
     } else {
       return (
         <div className='password-reset-form'>
-          <div>{this.context.intl.formatMessage({id: 'accounts.info_password_changed'})}!</div>
+          <div>{this.context.intl.formatMessage({id: 'accounts.info_password_changed'})}</div>
         </div>
       );
     }


### PR DESCRIPTION
There's already a period. I think an exclamation mark is over-enthusiastic, but maybe people like resetting their passwords.

Before:

![passwordchanged](https://user-images.githubusercontent.com/1735266/49272056-0171c280-f425-11e8-9ff8-47fb9eb821d7.png)

After:

![passwordchanged](https://user-images.githubusercontent.com/1735266/49272058-046cb300-f425-11e8-922c-fa7f820e08db.png)