### PR TITLE
Allow extra graphQL variables for field-specific queries

### DIFF
--- a/packages/vulcan-lib/lib/modules/graphql_templates.js
+++ b/packages/vulcan-lib/lib/modules/graphql_templates.js
@@ -247,8 +247,9 @@ query singleMovieQuery($input: SingleMovieInput) {
 }
 
 */
-export const singleClientTemplate = ({ typeName, fragmentName, extraQueries }) =>
-`query single${typeName}Query($input: Single${typeName}Input) {
+// LESSWRONG: Add extraVariables String
+export const singleClientTemplate = ({ typeName, fragmentName, extraQueries, extraVariablesString }) =>
+`query single${typeName}Query($input: Single${typeName}Input, ${extraVariablesString || ''}) {
   ${Utils.camelCaseify(typeName)}(input: $input) {
     result {
       ...${fragmentName}


### PR DESCRIPTION
This allows us to pass in an `extraVariables` field into the options of `withDocument`, which we can use to pass on custom data to graphQL queries. 

This is particularly useful for having fields that themselves resolve based on some available data. The immediate use-case for this was to make revisions work, by providing an optional argument to the `content` field which allows the user to resolve the content for a specific revision. 