### PR TITLE
Set `ssrForceFetchDelay` option [waits until Apollo 2.0]

### DIFF
--- a/packages/vulcan-lib/lib/modules/apollo.js
+++ b/packages/vulcan-lib/lib/modules/apollo.js
@@ -94,6 +94,8 @@ const meteorClientConfig = networkInterfaceConfig => {
       }
       return null;
     },
+    
+    ssrForceFetchDelay: Meteor.isServer ? 0 : 5000,
   }
 };
 


### PR DESCRIPTION
In combination with updating to Apollo 2.0, this will eliminate duplicate queries coming from PostsList on front-page load. Absent the Apollo 2.0 upgrade, it doesn't do anything because, while Apollo 1.0 theoretically supports the option, it has a bug which makes it not apply to the fetchMode we use.