### PR TITLE
Saved pages abort javascript on restore, display SSR

### DIFF
--- a/packages/vulcan-routing/lib/client/router.jsx
+++ b/packages/vulcan-routing/lib/client/router.jsx
@@ -53,7 +53,7 @@ export const RouterClient = {
       
       let serverUrl = await getDataPromisified('url');
       if (serverUrl && serverUrl !== window.location.pathname+(window.location.search||"")) {
-        throw new Error(`RouterClient sees a URL mismatch: ${data} vs ${window.location.pathname}`);
+        throw new Error(`RouterClient sees a URL mismatch: ${serverUrl} vs ${window.location.pathname}`);
       }
 
       // Rehydrate data client side, if desired.

--- a/packages/vulcan-routing/lib/client/router.jsx
+++ b/packages/vulcan-routing/lib/client/router.jsx
@@ -7,6 +7,8 @@ import { Meteor } from 'meteor/meteor';
 import { InjectData } from 'meteor/vulcan:lib';
 import { splitComponentRegistry } from '../modules/splitComponents';
 
+import * as Sentry from '@sentry/browser';
+
 const getDataPromisified = (name) => {
   return new Promise((resolve, reject)=> {
     try {
@@ -53,7 +55,8 @@ export const RouterClient = {
       
       let serverUrl = await getDataPromisified('url');
       if (serverUrl && serverUrl !== window.location.pathname+(window.location.search||"")) {
-        throw new Error(`RouterClient sees a URL mismatch: ${serverUrl} vs ${window.location.pathname}`);
+        //throw new Error(`RouterClient sees a URL mismatch: ${serverUrl} vs ${window.location.pathname}`);
+        Sentry.captureException(new Error(`RouterClient sees a URL mismatch: ${serverUrl} vs ${window.location.pathname}`));
       }
 
       // Rehydrate data client side, if desired.

--- a/packages/vulcan-routing/lib/client/router.jsx
+++ b/packages/vulcan-routing/lib/client/router.jsx
@@ -50,6 +50,11 @@ export const RouterClient = {
 
         document.body.appendChild(rootElement);
       }
+      
+      let serverUrl = await getDataPromisified('url');
+      if (serverUrl && serverUrl !== window.location.pathname+(window.location.search||"")) {
+        throw new Error(`RouterClient sees a URL mismatch: ${data} vs ${window.location.pathname}`);
+      }
 
       // Rehydrate data client side, if desired.
       if (typeof options.rehydrateHook === 'function') {

--- a/packages/vulcan-routing/lib/server/router.jsx
+++ b/packages/vulcan-routing/lib/server/router.jsx
@@ -86,6 +86,9 @@ function generateSSRData(options, req, res, renderProps) {
 
     // send server timezone to client
     InjectData.pushData(res, 'utcOffset', moment().utcOffset());
+    
+    // send the URL that is being rendered to the client
+    InjectData.pushData(res, 'url', req.url);
 
     if (options.postRender) {
       options.postRender(req, res);


### PR DESCRIPTION
Fixes https://github.com/VulcanJS/Vulcan/issues/2218 (Vulcan) / https://github.com/LessWrong2/Lesswrong2/issues/638 (LW). This is the minimal fix, not the ideal fix; rather than configure `react-router` in a way that makes it render the correct route, we bail out of Javascript execution with an uncaught exception, leaving the SSR in place, but without any interactivity.