### PR TITLE
Fix weird scoping issue in Sign Up flow

### DIFF
--- a/packages/vulcan-accounts/imports/ui/components/LoginFormInner.jsx
+++ b/packages/vulcan-accounts/imports/ui/components/LoginFormInner.jsx
@@ -817,7 +817,7 @@ export class AccountsLoginFormInner extends TrackerComponent {
       options.password = password;
     }
 
-    const SignUp = function(_options) {
+    const SignUp = (_options) => {
       Accounts.createUser(_options, (error) => {
         if (error) {
           // eslint-disable-next-line no-console


### PR DESCRIPTION
So, this PR feels somewhat doomy. The code really looks like it intentionally chose a normal function over an arrow function on that line, but I have no idea how line 826 was supposed to work with that (though maybe it is actually supposed to refer to some foreign `this`). 

I did test the signup after making it an arrow function and found that it worked fine, and also tested the error case where it now properly displayed a message. But still weird. 